### PR TITLE
fix(ordersList): Time stamp corrected

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -8,6 +8,10 @@ const OrdersList = (props) => {
         </div>
     );
 
+const num = n => {
+    return n<10 ? '0'+n : n
+}
+
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
         return (
@@ -17,7 +21,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {`${num(createdDate.getHours())}:${num(createdDate.getMinutes())}:${num(createdDate.getSeconds())}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
Created a function to display correct time stamp.

## Purpose
Before the issue was resolved, single digit times would display at 1 integer.

## Approach
The function allows 2 integers to show for time stamp 'hh:mm:ss'.

## Pre-Testing TODOs
Added 'const num' with function to show 2 integers. After completed, 'num' to each 'getHours', 'getMinutes', and 'getSeconds'.

## Testing Steps
After placing an order, go to the 'view orders' page and check the time stamp of the order placed. The formatting should be displayed as 'hh:mm:ss'.

## Learning
Basic knowledge of vanilla js understanding.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #2
